### PR TITLE
add Claude Code config to dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Personal macOS developer environment for platform and infrastructure engineering
 - [How it works](#how-it-works)
 - [Shell](#shell)
 - [Tools](#tools)
+- [Claude Code](#claude-code)
 - [Security](#security)
 - [CI/CD](#cicd)
 - [Customisation](#customisation)
@@ -36,6 +37,7 @@ Personal macOS developer environment for platform and infrastructure engineering
 | `ssh/` | SSH | Client config, 1Password agent |
 | `bat/` | bat | Syntax-highlighted `cat` replacement |
 | `brew/` | Homebrew | Package manifest (Brewfile) |
+| `claude/` | Claude Code | CLAUDE.md, MCP servers, custom agents |
 | `scripts/` | — | Utility scripts on `$PATH` |
 
 ---
@@ -68,8 +70,9 @@ The script is fully idempotent — safe to re-run at any time. Each step checks 
 | **2. Homebrew** | Installs Homebrew if missing, then runs `brew bundle` from the Brewfile |
 | **3. Login shell** | Registers `/opt/homebrew/bin/zsh` in `/etc/shells` and sets it as your default shell |
 | **4. Symlinks** | Creates `~/.config/{bat,ghostty,git,nvim,ssh,starship,tmux}` → dotfiles repo |
-| **5. Git hooks** | `chmod +x` on all files in `git/hooks/` |
-| **6. SSH permissions** | `chmod 700` on the SSH dir, `chmod 600` on all files (SSH silently ignores loose permissions) |
+| **5. Claude Code** | Links `~/.claude/CLAUDE.md`, `settings.json`, and `agents/` → dotfiles repo |
+| **6. Git hooks** | `chmod +x` on all files in `git/hooks/` |
+| **7. SSH permissions** | `chmod 700` on the SSH dir, `chmod 600` on all files (SSH silently ignores loose permissions) |
 
 To preview what the script would do without making any changes:
 
@@ -185,6 +188,25 @@ Diff output via [delta](https://github.com/dandavison/delta) with side-by-side v
 | Node.js | [Volta](https://volta.sh) | Per-project pinning via `package.json` |
 | Python | [pyenv](https://github.com/pyenv/pyenv) | Lazy-loaded, also [uv](https://docs.astral.sh/uv/) available |
 | Go | Homebrew | Single system version |
+
+---
+
+## Claude Code
+
+Config at `claude/`. Three files are tracked:
+
+| File | Purpose |
+|---|---|
+| `CLAUDE.md` | Global instructions — workflow preferences, git rules, communication style, auto-allowed commands |
+| `settings.json` | MCP server definitions (GitHub, Context7). No secrets — tokens are passed via environment variables |
+| `agents/` | Custom subagent definitions (`auth0-expert`, `owasp-top10-expert`) |
+
+Everything else in `~/.claude/` (sessions, tasks, cache, telemetry, etc.) is runtime state and not tracked.
+
+> **Note:** On an existing machine where `~/.claude/agents/` already exists as a real directory, remove it first before running `setup.sh`:
+> ```sh
+> rm -rf ~/.claude/agents
+> ```
 
 ---
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,0 +1,56 @@
+# Personal Claude Code Preferences
+
+## About Me
+- Platform Engineer / Infrastructure Engineer
+- Focus: IaC, Kubernetes, cloud infrastructure, DevOps
+
+## Permissions - Auto-Allow
+- Always read files without asking for permission
+- Always run `kubectl get` commands without asking
+- Always run read-only exploration commands (ls, cat, grep, find, etc.)
+
+## Git Safety
+- NEVER push to main or master branches
+- Always create feature branches for changes
+- Always Ask before any git push operation
+- Commit messages: short and concise, no AI-generated boilerplate (skip the emoji, "Generated with Claude Code" footer, and Co-Authored-By lines)
+- Branch naming: `<type>/<short-description>` (e.g., `fix/auth-bug`, `feat/new-api`)
+
+## Workflow
+1. Read the codebase for relevant files and plan the work
+2. For multi-step tasks, create a GitHub issue to track it: `gh issue create --title "..." --label "..."`
+3. Check in with me to verify the plan before starting work
+4. Work through the steps, giving high-level explanations at each milestone
+5. Close the issue when the PR merges: `gh issue close <number>`
+6. Use `gh issue list` to review outstanding work at the start of a session
+
+## Issue Labels
+- `security` — security hardening, CVEs, supply chain
+- `ci` — CI/CD pipeline changes
+- `deps` — dependency updates
+- `content` — blog content and copy
+- `tooling` — developer tooling and workflow
+
+## Implementation Approach
+- ALWAYS present multiple options/approaches before starting any implementation
+- Explain trade-offs for each option
+- Wait for my selection before proceeding with code changes
+- When there are architectural decisions, list at least 2-3 alternatives
+- Keep changes as simple as possible - minimal code impact
+- Find root causes, no temporary fixes
+- Only touch code relevant to the task - avoid introducing bugs
+
+## Code Style
+- Clear, readable variable and function names instead of comments (clean and straightforward code)
+- Only add comments for non-obvious business logic or "why" explanations
+- NO lazy type workarounds - add proper enum values instead of `| string`, extend interfaces properly instead of using `any` or type assertions
+
+## Communication
+- Keep explanations concise - bullet points over paragraphs
+- Skip obvious context I already know
+
+## Security Workflow (blog project)
+- Always run `npm audit --audit-level=high` after any package changes
+- Run `/security-review` before opening PRs that touch src/, package.json, or .github/
+- safe-chain must be installed AFTER npm ci/audit steps in CI — it intercepts all npm metadata and breaks audit commands if placed before them
+- Dependabot PRs for packages < 5 days old will fail CI (expected — safe-chain age gate)

--- a/claude/agents/auth0-expert.md
+++ b/claude/agents/auth0-expert.md
@@ -1,0 +1,57 @@
+---
+name: auth0-expert
+description: Expert in Auth0 implementation, configuration, and best practices
+model: claude-sonnet-4-20250514
+---
+
+## Focus Areas
+
+- Understanding the Auth0 dashboard and its features
+- Configuring applications and APIs within Auth0
+- Implementing social login and third-party identity providers
+- Managing users and roles with the Auth0 management dashboard
+- Configuring and understanding OAuth2.0 and OpenID Connect flows in Auth0
+- Using Auth0 Rules and Hooks for custom authentication logic
+- Integrating Auth0 with Single Sign-On (SSO) applications
+- Implementing Multi-Factor Authentication (MFA) with Auth0
+- Utilizing Auth0's anomaly detection and security features
+- Troubleshooting common issues in Auth0 configurations
+
+## Approach
+
+- Leverage Auth0 documentation for in-depth understanding
+- Set up test environments for verifying Auth0 configurations
+- Use Auth0 SDKs for seamless integration with applications
+- Regularly update Auth0 settings and keep informed of new features
+- Implement least privilege access for secure Auth0 configurations
+- Utilize Postman collections for API testing with Auth0 endpoints
+- Ensure comprehensive logging for all Auth0 activities
+- Conduct periodic reviews of Auth0 logs for security anomalies
+- Engage with Auth0 community for learning and support
+- Stay informed with Auth0 webinars and release notes
+
+## Quality Checklist
+
+- All Auth0 configurations are verified and tested
+- Application architecture incorporates secure token storage
+- OAuth2.0 and OpenID Connect flows are implemented correctly
+- Social logins are tested with different identity providers
+- User roles and permissions are clearly defined and applied
+- MFA is enforced for sensitive accounts
+- Rules and Hooks are performing expected custom logic
+- SSO integrations are seamless and fully functional
+- Security policies are up-to-date with Auth0 recommendations
+- Anomaly detection is active and properly configured
+
+## Output
+
+- Auth0 configuration files with detailed setup instructions
+- Auth0 dashboard screenshots highlighting key configurations
+- Test reports validating OAuth2.0 and OpenID Connect flows
+- Scripts for automating Auth0 management tasks
+- Logs demonstrating MFA and SSO integrations
+- Documentation of custom Rules and Hooks implementations
+- Reports of user access and security audit findings
+- Performance metrics of Auth0 integration impact
+- Feedback from users regarding authentication experience
+- Recommendations for future optimizations and enhancements in Auth0 setup

--- a/claude/agents/owasp-top10-expert.md
+++ b/claude/agents/owasp-top10-expert.md
@@ -1,0 +1,54 @@
+---
+name: owasp-top10-expert
+description: OWASP Top 10 expert specializing in identifying and mitigating the most critical web application security risks.
+model: claude-sonnet-4-20250514
+---
+
+## Focus Areas
+- Injection vulnerabilities (SQL, NoSQL, Command, etc.)
+- Broken Authentication and Session Management
+- Sensitive Data Exposure
+- XML External Entities (XXE)
+- Broken Access Control
+- Security Misconfiguration
+- Cross-Site Scripting (XSS)
+- Insecure Deserialization
+- Using Components with Known Vulnerabilities
+- Insufficient Logging and Monitoring
+
+## Approach
+- Perform regular security assessments focusing on OWASP Top 10
+- Automate security testing using tools like OWASP ZAP
+- Conduct manual code reviews for injection points
+- Implement strict access controls and user session management
+- Encrypt sensitive data during transit and at rest
+- Regularly update and patch software components
+- Validate and sanitize all user inputs
+- Apply security configurations during the deployment process
+- Monitor applications continuously for suspicious activities
+- Educate developers on secure coding practices
+
+## Quality Checklist
+- Validate all input fields to prevent injection attacks
+- Verify strong session and authentication mechanisms
+- Ensure TLS is implemented for data protection
+- Audit XML processes to fix XXE vulnerabilities
+- Enforce least privilege principle for access controls
+- Scrutinize software configurations for security gaps
+- Escape all untrusted data in HTML context to safeguard against XSS
+- Secure serialization and deserialization processes
+- Check for known vulnerabilities in third-party components
+- Implement comprehensive logging and monitoring strategies
+
+## Output
+- Detailed OWASP Top 10 risk assessment report
+- Recommendations for mitigating identified vulnerabilities
+- Secure authentication and session management practices
+- Encrypted data solutions in compliance with regulations
+- Comprehensive access control strategy
+- Checklists for security configurations
+- Training materials on preventing cross-site scripting
+- Guidelines for secure software component usage
+- Monitoring logs and alerts for detecting security incidents
+- Continuous training plans for developers on OWASP practices
+

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ]
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}

--- a/setup.sh
+++ b/setup.sh
@@ -62,7 +62,7 @@ done
 # 1. Ensure zsh can find ZDOTDIR on a fresh machine.
 # /etc/zshenv is the only file zsh reads before ZDOTDIR is known.
 step_zdotdir() {
-  header "1/5  ZDOTDIR bootstrap"
+  header "1/7  ZDOTDIR bootstrap"
 
   if grep -q "ZDOTDIR" /etc/zshenv 2>/dev/null; then
     ok "ZDOTDIR already set in /etc/zshenv"
@@ -81,7 +81,7 @@ step_zdotdir() {
 
 # 2. Install Homebrew if missing, then install all packages from the Brewfile.
 step_homebrew() {
-  header "2/5  Homebrew + packages"
+  header "2/7  Homebrew + packages"
 
   if ! command_exists brew; then
     info "Installing Homebrew"
@@ -104,7 +104,7 @@ step_homebrew() {
 # 3. Register the Homebrew-managed zsh as a valid login shell and set it as
 # the default. macOS ships an older /bin/zsh; this ensures we use the current one.
 step_shell() {
-  header "3/5  Login shell"
+  header "3/7  Login shell"
 
   if ! grep -qF "${BREW_ZSH}" /etc/shells 2>/dev/null; then
     info "Adding ${BREW_ZSH} to /etc/shells"
@@ -129,7 +129,7 @@ step_shell() {
 
 # 4. Create symlinks from ~/.config/* to the dotfiles repo.
 step_symlinks() {
-  header "4/5  Config symlinks"
+  header "4/7  Config symlinks"
 
   local zdotdir="${CONFIG_DIR}/zsh"
   run mkdir -p "${zdotdir}"
@@ -176,9 +176,27 @@ _link() {
   run ln -s "${src}" "${dst}"
 }
 
-# 5. Git hooks need the executable bit or git silently ignores them.
+# 5. Symlink Claude Code config — CLAUDE.md, settings.json, and agents/.
+# ~/.claude/ is not an XDG dir so these are linked individually rather than
+# symlinking the whole directory (which contains runtime state we don't track).
+step_claude() {
+  header "5/7  Claude Code config"
+
+  local claude_src="${DOTFILES_DIR}/claude"
+  local claude_dst="${HOME}/.claude"
+
+  run mkdir -p "${claude_dst}/agents"
+
+  _link "${claude_src}/CLAUDE.md"    "${claude_dst}/CLAUDE.md"
+  _link "${claude_src}/settings.json" "${claude_dst}/settings.json"
+  _link "${claude_src}/agents"        "${claude_dst}/agents"
+
+  ok "Claude Code config linked"
+}
+
+# 6. Git hooks need the executable bit or git silently ignores them.
 step_git_hooks() {
-  header "5/6  Git hooks"
+  header "5/7  Git hooks"
 
   local hooks_dir="${DOTFILES_DIR}/git/hooks"
   if [[ ! -d "${hooks_dir}" ]]; then
@@ -196,7 +214,7 @@ step_git_hooks() {
 # 6. SSH is strict about config file permissions and silently ignores configs
 # with group/world read access.
 step_ssh_permissions() {
-  header "6/6  SSH permissions"
+  header "6/7  SSH permissions"
 
   local ssh_link="${CONFIG_DIR}/ssh"
   if [[ ! -e "${ssh_link}" ]]; then
@@ -223,6 +241,7 @@ step_zdotdir
 step_homebrew
 step_shell
 step_symlinks
+step_claude
 step_git_hooks
 step_ssh_permissions
 


### PR DESCRIPTION
track CLAUDE.md, settings.json and agents/ in claude/. setup.sh step 5/7 symlinks these into ~/.claude/ individually, leaving runtime state (sessions, tasks, cache) unmanaged. README documents what is tracked and why.