### PR TITLE
feat: macOS defaults + expanded pre-commit hooks with repo-local chaining

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Dotfiles repo-local pre-commit hook.
+# Invoked by the global hook at ~/.config/git/hooks/pre-commit.
+
+set -euo pipefail
+
+staged() { git diff --cached --name-only --diff-filter=ACM; }
+
+# ── YAML syntax on staged workflow files ──────────────────────────────────────
+
+mapfile -t yaml_files < <(staged | grep -E '\.(yml|yaml)$' || true)
+if (( ${#yaml_files[@]} > 0 )); then
+  echo "[pre-commit] yaml syntax (${#yaml_files[@]} file(s))..."
+  for f in "${yaml_files[@]}"; do
+    if ! ruby -e "require 'yaml'; YAML.load_file('${f}')" 2>/dev/null; then
+      echo "[pre-commit] YAML syntax error in ${f} — commit blocked."
+      exit 1
+    fi
+  done
+fi
+
+# ── taplo check on staged TOML files ──────────────────────────────────────────
+
+if command -v taplo &>/dev/null; then
+  mapfile -t toml_files < <(staged | grep '\.toml$' || true)
+  if (( ${#toml_files[@]} > 0 )); then
+    echo "[pre-commit] taplo check (${#toml_files[@]} file(s))..."
+    if ! taplo check "${toml_files[@]}"; then
+      echo "[pre-commit] TOML validation failed — commit blocked."
+      exit 1
+    fi
+  fi
+fi

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The script is fully idempotent — safe to re-run at any time. Each step checks 
 | **7. SSH include** | Adds `Include ~/.config/ssh/config` to `~/.ssh/config` so all SSH clients use the managed config |
 | **8. SSH permissions** | `chmod 700` on the SSH dir, `chmod 600` on all files (SSH silently ignores loose permissions) |
 | **9. Cleanup** | Removes legacy `~/.zshrc` / `~/.zshenv` (with ZDOTDIR set these are never sourced and cause confusion) |
+| **10. macOS defaults** | Applies developer-friendly system settings: fast key repeat, Finder tweaks, Dock auto-hide, screenshot format, expanded save dialogs, immediate screen-lock |
 
 To preview what the script would do without making any changes:
 

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -1,24 +1,84 @@
 #!/usr/bin/env bash
-# Pre-commit hook: scan staged changes for secrets using TruffleHog.
-# Installed globally via core.hooksPath in ~/.config/git/config.
+# Global pre-commit hook — runs in every repository via core.hooksPath.
+#
+# Checks (in order):
+#   1. No merge conflict markers in staged files
+#   2. No large files (>500 KB) staged
+#   3. shellcheck on staged .sh files
+#   4. TruffleHog secret scan
+#   5. Repo-local hook at .githooks/pre-commit (if present and executable)
+
+set -euo pipefail
+
+staged() { git diff --cached --name-only --diff-filter=ACM; }
+
+# ── 1. Merge conflict markers ──────────────────────────────────────────────────
+
+conflict_files=$(staged | xargs grep -rl "^<<<<<<< " 2>/dev/null || true)
+if [[ -n "${conflict_files}" ]]; then
+  echo ""
+  echo "[pre-commit] merge conflict markers found in:"
+  echo "${conflict_files}" | sed 's/^/             /'
+  echo "             Resolve conflicts before committing."
+  exit 1
+fi
+
+# ── 2. Large file guard (>500 KB) ─────────────────────────────────────────────
+
+max_bytes=512000
+while IFS= read -r file; do
+  [[ -f "${file}" ]] || continue
+  size=$(wc -c < "${file}")
+  if (( size > max_bytes )); then
+    echo ""
+    echo "[pre-commit] large file blocked: ${file} ($(( size / 1024 )) KB > 500 KB)"
+    echo "             Use git-lfs for large assets, or review if this file should be committed."
+    exit 1
+  fi
+done < <(staged)
+
+# ── 3. shellcheck on staged .sh files ─────────────────────────────────────────
+
+if command -v shellcheck &>/dev/null; then
+  mapfile -t sh_files < <(staged | grep '\.sh$' || true)
+  if (( ${#sh_files[@]} > 0 )); then
+    echo "[pre-commit] shellcheck (${#sh_files[@]} file(s))..."
+    if ! shellcheck --severity=error "${sh_files[@]}"; then
+      echo ""
+      echo "[pre-commit] shellcheck found errors — commit blocked."
+      exit 1
+    fi
+  fi
+else
+  echo "[pre-commit] shellcheck not found, skipping (run: brew install shellcheck)"
+fi
+
+# ── 4. TruffleHog secret scan ─────────────────────────────────────────────────
 
 if ! command -v trufflehog &>/dev/null; then
   echo "[pre-commit] trufflehog not found, skipping secret scan (run: brew install trufflehog)"
-  exit 0
+else
+  echo "[pre-commit] scanning for secrets..."
+  if trufflehog git "file://$(git rev-parse --show-toplevel)" \
+      --since-commit HEAD \
+      --only-verified \
+      --fail \
+      --no-update \
+      2>/dev/null; then
+    echo "[pre-commit] no secrets found"
+  else
+    echo ""
+    echo "[pre-commit] TruffleHog found verified secrets — commit blocked."
+    echo "             Review the output above, remove the secrets, then try again."
+    echo "             To skip this check (use with caution): git commit --no-verify"
+    exit 1
+  fi
 fi
 
-echo "[pre-commit] scanning for secrets..."
-if trufflehog git "file://$(git rev-parse --show-toplevel)" \
-    --since-commit HEAD \
-    --only-verified \
-    --fail \
-    --no-update \
-    2>/dev/null; then
-  echo "[pre-commit] no secrets found"
-else
-  echo ""
-  echo "[pre-commit] TruffleHog found verified secrets — commit blocked."
-  echo "             Review the output above, remove the secrets, then try again."
-  echo "             To skip this check (use with caution): git commit --no-verify"
-  exit 1
+# ── 5. Repo-local hook ────────────────────────────────────────────────────────
+
+repo_hook="$(git rev-parse --show-toplevel)/.githooks/pre-commit"
+if [[ -x "${repo_hook}" ]]; then
+  echo "[pre-commit] running repo-local hook..."
+  "${repo_hook}"
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -195,19 +195,21 @@ step_claude() {
 }
 
 # 6. Git hooks need the executable bit or git silently ignores them.
+# Also makes .githooks/ executable — these are repo-local hooks chained
+# from the global hook and must be executable to be invoked.
 step_git_hooks() {
   header "6/10  Git hooks"
 
-  local hooks_dir="${DOTFILES_DIR}/git/hooks"
-  if [[ ! -d "${hooks_dir}" ]]; then
-    warn "No hooks directory found at ${hooks_dir} — skipping"
-    return
-  fi
+  local -a hook_dirs=("${DOTFILES_DIR}/git/hooks" "${DOTFILES_DIR}/.githooks")
 
-  while IFS= read -r -d '' hook; do
-    info "chmod +x $(basename "${hook}")"
-    run chmod +x "${hook}"
-  done < <(find "${hooks_dir}" -type f -print0)
+  for hooks_dir in "${hook_dirs[@]}"; do
+    [[ -d "${hooks_dir}" ]] || continue
+    while IFS= read -r -d '' hook; do
+      info "chmod +x $(basename "${hook}")"
+      run chmod +x "${hook}"
+    done < <(find "${hooks_dir}" -type f -print0)
+  done
+
   ok "Git hooks executable"
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -62,7 +62,7 @@ done
 # 1. Ensure zsh can find ZDOTDIR on a fresh machine.
 # /etc/zshenv is the only file zsh reads before ZDOTDIR is known.
 step_zdotdir() {
-  header "1/9  ZDOTDIR bootstrap"
+  header "1/10  ZDOTDIR bootstrap"
 
   if grep -q "ZDOTDIR" /etc/zshenv 2>/dev/null; then
     ok "ZDOTDIR already set in /etc/zshenv"
@@ -81,7 +81,7 @@ step_zdotdir() {
 
 # 2. Install Homebrew if missing, then install all packages from the Brewfile.
 step_homebrew() {
-  header "2/9  Homebrew + packages"
+  header "2/10  Homebrew + packages"
 
   if ! command_exists brew; then
     info "Installing Homebrew"
@@ -104,7 +104,7 @@ step_homebrew() {
 # 3. Register the Homebrew-managed zsh as a valid login shell and set it as
 # the default. macOS ships an older /bin/zsh; this ensures we use the current one.
 step_shell() {
-  header "3/9  Login shell"
+  header "3/10  Login shell"
 
   if ! grep -qF "${BREW_ZSH}" /etc/shells 2>/dev/null; then
     info "Adding ${BREW_ZSH} to /etc/shells"
@@ -129,7 +129,7 @@ step_shell() {
 
 # 4. Create symlinks from ~/.config/* to the dotfiles repo.
 step_symlinks() {
-  header "4/9  Config symlinks"
+  header "4/10  Config symlinks"
 
   local zdotdir="${CONFIG_DIR}/zsh"
   run mkdir -p "${zdotdir}"
@@ -180,7 +180,7 @@ _link() {
 # ~/.claude/ is not an XDG dir so these are linked individually rather than
 # symlinking the whole directory (which contains runtime state we don't track).
 step_claude() {
-  header "5/9  Claude Code config"
+  header "5/10  Claude Code config"
 
   local claude_src="${DOTFILES_DIR}/claude"
   local claude_dst="${HOME}/.claude"
@@ -196,7 +196,7 @@ step_claude() {
 
 # 6. Git hooks need the executable bit or git silently ignores them.
 step_git_hooks() {
-  header "6/9  Git hooks"
+  header "6/10  Git hooks"
 
   local hooks_dir="${DOTFILES_DIR}/git/hooks"
   if [[ ! -d "${hooks_dir}" ]]; then
@@ -216,7 +216,7 @@ step_git_hooks() {
 # and use Include to pull in the managed config from the dotfiles repo.
 # OrbStack's Include must stay first (it adds Host blocks before any Match/Host).
 step_ssh_include() {
-  header "7/9  SSH include"
+  header "7/10  SSH include"
 
   local system_ssh="${HOME}/.ssh/config"
   local managed_include="Include ~/.config/ssh/config"
@@ -241,7 +241,7 @@ step_ssh_include() {
 # 8. SSH is strict about config file permissions and silently ignores configs
 # with group/world read access.
 step_ssh_permissions() {
-  header "8/9  SSH permissions"
+  header "8/10  SSH permissions"
 
   local ssh_link="${CONFIG_DIR}/ssh"
   if [[ ! -e "${ssh_link}" ]]; then
@@ -263,7 +263,7 @@ step_ssh_permissions() {
 # With ZDOTDIR set, ~/.zshrc is never sourced — it only causes confusion.
 # ~/.bashrc and ~/.bash_profile are left alone (may be used by scripts/tools).
 step_cleanup_shell() {
-  header "9/9  Clean up legacy shell files"
+  header "9/10  Clean up legacy shell files"
 
   local -a legacy=("${HOME}/.zshrc" "${HOME}/.zshenv")
   local removed=0
@@ -283,6 +283,81 @@ step_cleanup_shell() {
   [[ "${removed}" -eq 0 ]] && ok "No legacy shell files to remove"
 }
 
+# 10. Apply sensible macOS defaults for a developer environment.
+# All settings are idempotent — safe to re-run. Affected apps are restarted
+# at the end to pick up the new values.
+step_macos_defaults() {
+  header "10/10  macOS defaults"
+
+  # ── Keyboard ──────────────────────────────────────────────────────────────
+  # Faster key repeat — essential for vim and terminal work.
+  # System default: InitialKeyRepeat=25, KeyRepeat=6
+  run defaults write NSGlobalDomain KeyRepeat -int 2
+  run defaults write NSGlobalDomain InitialKeyRepeat -int 15
+  # Allow key repeat in all apps (disables the press-and-hold accent popup)
+  run defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
+  # Disable smart quotes, smart dashes, autocorrect — all break code
+  run defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
+  run defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
+  run defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
+  run defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
+  run defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
+
+  # ── Finder ────────────────────────────────────────────────────────────────
+  run defaults write com.apple.finder AppleShowAllFiles -bool true
+  run defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+  run defaults write com.apple.finder ShowPathbar -bool true
+  run defaults write com.apple.finder ShowStatusBar -bool true
+  # Show full POSIX path in Finder title bar
+  run defaults write com.apple.finder _FXShowPosixPathInTitle -bool true
+  # Search the current folder by default (not "This Mac")
+  run defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
+  # Keep folders on top when sorting by name
+  run defaults write com.apple.finder _FXSortFoldersFirst -bool true
+  # Default to list view
+  run defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"
+  # No warning when changing a file extension
+  run defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+  # Don't write .DS_Store on network or USB volumes
+  run defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+  run defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
+
+  # ── Dock ──────────────────────────────────────────────────────────────────
+  run defaults write com.apple.dock autohide -bool true
+  # Remove the auto-hide show/hide delay
+  run defaults write com.apple.dock autohide-delay -float 0
+  run defaults write com.apple.dock autohide-time-modifier -float 0.4
+  # Don't show recently used apps in Dock
+  run defaults write com.apple.dock show-recents -bool false
+  # Don't reorder Spaces based on most recent use
+  run defaults write com.apple.dock mru-spaces -bool false
+
+  # ── Screenshots ───────────────────────────────────────────────────────────
+  run defaults write com.apple.screencapture type -string "png"
+  run defaults write com.apple.screencapture disable-shadow -bool true
+
+  # ── Dialogs ───────────────────────────────────────────────────────────────
+  # Expand save and print panels by default instead of showing the compact form
+  run defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode -bool true
+  run defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode2 -bool true
+  run defaults write NSGlobalDomain PMPrintingExpandedStateForPrint -bool true
+  run defaults write NSGlobalDomain PMPrintingExpandedStateForPrint2 -bool true
+
+  # ── Security ──────────────────────────────────────────────────────────────
+  # Require password immediately after sleep or screensaver begins
+  run defaults write com.apple.screensaver askForPassword -int 1
+  run defaults write com.apple.screensaver askForPasswordDelay -int 0
+
+  # Restart affected apps to apply changes
+  if ! $DRY_RUN; then
+    killall Finder
+    killall Dock
+    killall SystemUIServer 2>/dev/null || true
+  fi
+
+  ok "macOS defaults applied"
+}
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 printf "\n  dotfiles setup\n  %s\n" "${DOTFILES_DIR}"
@@ -297,6 +372,7 @@ step_git_hooks
 step_ssh_include
 step_ssh_permissions
 step_cleanup_shell
+step_macos_defaults
 
 printf "\n${DIM}── done ──────────────────────────────────────────────${RESET}\n\n"
 if ! $DRY_RUN; then


### PR DESCRIPTION
## Summary

### macOS defaults (step 10/10)
New setup step applies developer-friendly system settings on fresh machine setup:
- **Keyboard**: key repeat rate 2 (from 6), initial delay 15 (from 25), disable press-and-hold popup, disable smart quotes/dashes/autocorrect/autocap (all break code)
- **Finder**: show hidden files + all extensions, path bar, status bar, full POSIX path in title, search current folder, list view, no extension-change warning, no `.DS_Store` on network/USB
- **Dock**: auto-hide with no delay, no recent apps, no space reordering
- **Screenshots**: PNG, no drop shadow
- **Dialogs**: expanded save and print panels by default
- **Security**: require password immediately after sleep/screensaver

### Pre-commit hook expansion
Global hook now runs four checks in sequence before delegating to repo-local hooks:
1. Merge conflict marker detection in staged files
2. Large file guard (>500 KB)
3. `shellcheck` on staged `.sh` files
4. TruffleHog secret scan (moved to step 4)
5. Chains to `.githooks/pre-commit` if present and executable

### Repo-local hook chaining
Add `.githooks/pre-commit` for the dotfiles repo:
- YAML syntax check on staged `.yml`/`.yaml` files (Ruby stdlib, no extra deps)
- `taplo` validation on staged `.toml` files

Any other repo (Terraform, K8s, etc.) can now get per-repo hooks by adding `.githooks/pre-commit` — the global hook picks it up automatically.

`setup.sh` step 6 updated to `chmod +x` both `git/hooks/` and `.githooks/`.

## Test plan
- [ ] `bash setup.sh --dry-run` completes all 10 steps without errors
- [ ] Staging a file with `<<<<<<< ` blocks commit with conflict marker message
- [ ] Staging a file >500 KB blocks commit with size message
- [ ] Staging a `.sh` file with a shellcheck error blocks commit
- [ ] Staging a malformed `.yml` file blocks commit via local hook
- [ ] Clean commit goes through with all checks passing