### PR TITLE
fix: disable AddKeysToAgent, fix pre-commit bash shebang

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/opt/homebrew/bin/bash
 # Dotfiles repo-local pre-commit hook.
 # Invoked by the global hook at ~/.config/git/hooks/pre-commit.
 

--- a/git/hooks/pre-commit
+++ b/git/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/opt/homebrew/bin/bash
 # Global pre-commit hook — runs in every repository via core.hooksPath.
 #
 # Checks (in order):

--- a/ssh/config
+++ b/ssh/config
@@ -2,6 +2,8 @@ Host *
   IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
   ServerAliveInterval 60
   ServerAliveCountMax 3
-  AddKeysToAgent yes
+  # Explicitly no: AddKeysToAgent adds to SSH_AUTH_SOCK (macOS Keychain agent), not IdentityAgent.
+  # This caused keys to be fetched from Keychain instead of 1Password. 1Password manages its own keys.
+  AddKeysToAgent no
   StrictHostKeyChecking ask
   HashKnownHosts yes


### PR DESCRIPTION
## Summary

- Set `AddKeysToAgent no` in SSH config with comment explaining why — `AddKeysToAgent yes` was adding keys to `SSH_AUTH_SOCK` (macOS Keychain agent) instead of the 1Password `IdentityAgent`, causing SSH keys to be fetched from Keychain
- Fix `#!/usr/bin/env bash` shebang in both pre-commit hooks to use `/opt/homebrew/bin/bash` — hooks use `mapfile` (bash 4+) but macOS system bash is 3.2, causing hook failures

## Test plan

- [ ] `git commit` runs pre-commit hooks without `mapfile: command not found` error
- [ ] SSH auth to GitHub uses 1Password (check via `ssh -T git@github.com` and confirm 1Password prompts)