### PR TITLE
chore(setup): drop AppleAccentColor write so Custom Color survives re-runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The script is fully idempotent — safe to re-run at any time. Each step checks 
 | **7. SSH include** | Adds `Include ~/.config/ssh/config` to `~/.ssh/config` so all SSH clients use the managed config |
 | **8. SSH permissions** | `chmod 700` on the SSH dir, `chmod 600` on all files (SSH silently ignores loose permissions) |
 | **9. Cleanup** | Removes legacy `~/.zshrc` / `~/.zshenv` (with ZDOTDIR set these are never sourced and cause confusion) |
-| **10. macOS defaults** | Applies developer-friendly system settings: fast key repeat, Finder tweaks, Dock auto-hide, screenshot format, expanded save dialogs, immediate screen-lock, system accent set to Pink (closest match to the dawnfox terminal palette) |
+| **10. macOS defaults** | Applies developer-friendly system settings: fast key repeat, Finder tweaks, Dock auto-hide, screenshot format, expanded save dialogs, immediate screen-lock |
 | **11. AeroSpace** | Reloads AeroSpace's config (symlink updates take effect without a restart) |
 | **12. Application Accessibility** | Launches AeroSpace and Sol, opens System Settings → Privacy → Accessibility once, and waits for a single confirmation covering both apps |
 
@@ -90,6 +90,7 @@ A few things macOS won't let scripts do silently. setup.sh prompts at the right 
 | Grant **AeroSpace** Accessibility | TCC requires a human toggle to allow window management | System Settings → Privacy & Security → Accessibility |
 | Grant **Sol** Accessibility | Same TCC requirement for global hotkeys + app discovery | System Settings → Privacy & Security → Accessibility |
 | Bind **Sol's** global hotkey | Sol opens a settings window on first launch — pick a hotkey that doesn't collide with Spotlight (e.g. `⌥ Space`) | Sol → Settings → General → Global Shortcut |
+| Set **system accent** to dawnfox pine | macOS won't let `defaults write` set a Custom Color hex; preset accents (Pink, Purple, etc.) all clash with the cream terminal palette | System Settings → Appearance → Accent → Custom Color → `#286983` |
 
 To preview what the script would do without making any changes:
 

--- a/setup.sh
+++ b/setup.sh
@@ -372,12 +372,11 @@ step_macos_defaults() {
   run defaults write NSGlobalDomain PMPrintingExpandedStateForPrint2 -bool true
 
   # ── Appearance ────────────────────────────────────────────────────────────
-  # Pink accent — closest macOS preset to the dawnfox rose (#b4637a) used
-  # across the terminal stack. Picked up by Sol launcher and other apps that
-  # read the system accent live. Values: -1=Graphite, 0=Red, 1=Orange,
-  # 2=Yellow, 3=Green, 4=Blue (default), 5=Purple, 6=Pink.
-  run defaults write NSGlobalDomain AppleAccentColor -int 6
-  run defaults write NSGlobalDomain AppleHighlightColor -string "1.000000 0.749020 0.823529 Pink"
+  # Accent + highlight are NOT set here. macOS doesn't expose a clean defaults
+  # key for the Tahoe Custom Color picker (the hex lives in encoded form), and
+  # writing AppleAccentColor would clobber a manually-picked Custom Color on
+  # every re-run. Set Custom Color #286983 (dawnfox pine) once via System
+  # Settings → Appearance → Accent → Custom Color.
 
   # ── Security ──────────────────────────────────────────────────────────────
   # Require password immediately after sleep or screensaver begins
@@ -456,6 +455,7 @@ if ! $DRY_RUN; then
   printf "  ${YELLOW}Manual follow-ups${RESET} (macOS won't let scripts do these silently):\n"
   printf "    • Grant AeroSpace Accessibility → System Settings → Privacy & Security → Accessibility\n"
   printf "    • Grant Sol Accessibility       → System Settings → Privacy & Security → Accessibility\n"
-  printf "    • Bind Sol's global hotkey      → Sol → Settings → General → Global Shortcut\n\n"
+  printf "    • Bind Sol's global hotkey      → Sol → Settings → General → Global Shortcut\n"
+  printf "    • Set system accent to Pine     → System Settings → Appearance → Custom Color #286983\n\n"
   printf "  Then restart your terminal to apply all changes.\n\n"
 fi


### PR DESCRIPTION
## Summary
- Drop `AppleAccentColor` and `AppleHighlightColor` writes from `step_macos_defaults`. They were clobbering any manually-picked Custom Color back to Pink on every re-run, since Tahoe's Custom Color hex isn't exposed via a clean `defaults` key
- Recommend Pine `#286983` (dawnfox-canonical) as the Custom Color: ~6:1 contrast with white text vs Rose `#b4637a` at ~3.4:1 — Sol's selected-row text was barely legible on Pink
- Manual follow-up surfaced in both `README.md` and `setup.sh`'s final output, alongside the existing AeroSpace / Sol Accessibility reminders

## Test plan
- [x] `bash -n setup.sh` clean
- [x] `setup.sh --dry-run` walks all 12 steps
- [x] `step_macos_defaults` no longer touches accent/highlight keys