### PR TITLE
fix(rustcast): claim CMD+Space, disable Spotlight, drop deprecated key

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A few things macOS won't let scripts do silently. setup.sh prompts at the right 
 | Grant **AeroSpace** Accessibility | TCC requires a human toggle to allow window management | System Settings → Privacy & Security → Accessibility |
 | Grant **RustCast** Accessibility | Same TCC requirement for global hotkeys + app discovery | System Settings → Privacy & Security → Accessibility |
 | Set **system accent** to dawnfox pine | macOS won't let `defaults write` set a Custom Color hex; preset accents (Pink, Purple, etc.) all clash with the cream terminal palette | System Settings → Appearance → Accent → Custom Color → `#286983` |
+| **Logout/login** after first run | Disabling Spotlight's `⌘ Space` (so RustCast can claim it) requires the macOS hotkey daemon to reload — only happens at login | Apple menu → Log Out |
 
 To preview what the script would do without making any changes:
 

--- a/rustcast/config.toml
+++ b/rustcast/config.toml
@@ -1,6 +1,6 @@
-# Toggle hotkey — ALT+SPACE matches the launcher convention on macOS without
-# colliding with Spotlight (CMD+SPACE). RustCast normalises ALT == OPTION.
-toggle_hotkey = "ALT+SPACE"
+# Toggle hotkey — CMD+SPACE (Spotlight's slot). step_macos_defaults disables
+# Spotlight's binding so RustCast can claim it. RustCast spells CMD as SUPER.
+toggle_hotkey = "SUPER+SPACE"
 
 placeholder = "Search apps, files, ?web"
 
@@ -27,7 +27,6 @@ text_color       = [0.341, 0.322, 0.475]
 # bg #faf4ed cream   → 250/244/237
 background_color = [0.980, 0.957, 0.929]
 
-background_opacity = 1.0
 blur = false
 show_icons = true
 show_scroll_bar = true

--- a/setup.sh
+++ b/setup.sh
@@ -378,6 +378,17 @@ step_macos_defaults() {
   # every re-run. Set Custom Color #286983 (dawnfox pine) once via System
   # Settings → Appearance → Accent → Custom Color.
 
+  # ── Hotkeys ───────────────────────────────────────────────────────────────
+  # Disable Spotlight's CMD+Space binding (key 64 in symbolichotkeys.plist) so
+  # RustCast can claim it. Logout/login is required for the kernel-level hotkey
+  # daemon to pick up the change — running 'killall Dock' won't fix it.
+  if ! $DRY_RUN; then
+    /usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:64:enabled false" \
+      "${HOME}/Library/Preferences/com.apple.symbolichotkeys.plist" 2>/dev/null || true
+  else
+    dry "PlistBuddy disable AppleSymbolicHotKeys:64 (Spotlight CMD+Space)"
+  fi
+
   # ── Security ──────────────────────────────────────────────────────────────
   # Require password immediately after sleep or screensaver begins
   run defaults write com.apple.screensaver askForPassword -int 1
@@ -455,6 +466,7 @@ if ! $DRY_RUN; then
   printf "  ${YELLOW}Manual follow-ups${RESET} (macOS won't let scripts do these silently):\n"
   printf "    • Grant AeroSpace Accessibility → System Settings → Privacy & Security → Accessibility\n"
   printf "    • Grant RustCast Accessibility  → System Settings → Privacy & Security → Accessibility\n"
-  printf "    • Set system accent to Pine     → System Settings → Appearance → Custom Color #286983\n\n"
+  printf "    • Set system accent to Pine     → System Settings → Appearance → Custom Color #286983\n"
+  printf "    • Logout/login                  → so disabled Spotlight CMD+Space frees up for RustCast\n\n"
   printf "  Then restart your terminal to apply all changes.\n\n"
 fi


### PR DESCRIPTION
## Summary
- Toggle hotkey: `ALT+SPACE` → `SUPER+SPACE` (CMD+Space). ALT+SPACE collides with the macOS window-menu shortcut in some apps; CMD+Space is the real launcher slot
- `step_macos_defaults` now PlistBuddy-disables Spotlight's CMD+Space binding (`AppleSymbolicHotKeys:64`) so RustCast can claim it. Idempotent. Logout/login required for the kernel hotkey daemon to reload — added to manual follow-ups
- Drop `background_opacity` from `rustcast/config.toml` — RustCast 0.4.5+ ignores it (per the project wiki)

## Test plan
- [x] `bash -n setup.sh` clean
- [x] PlistBuddy command applied locally; verified `enabled = false` for key 64
- [x] Logout/login note surfaced in both README and setup.sh's final output