### PR TITLE
feat(claude): skill-reminder hook covers gh pr merge; fix false positives

### DIFF
--- a/claude/hooks/skill-reminder.sh
+++ b/claude/hooks/skill-reminder.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# PreToolUse hook (Bash matcher): nudges toward the right skill when the
+# command-head is one of the gated git operations. Emits additionalContext
+# JSON; never blocks. Stays warn-only.
+#
+# Lives at user level because the same skills are in use across every Claude
+# Code session that operates in the backmanfyi monorepo (and any future repo
+# adopting the same skill names).
+#
+# Matching rule: only nudges if the command STARTS WITH the gated phrase.
+# This avoids false positives when commit messages or PR bodies contain the
+# literal string (which bit us repeatedly before the rewrite).
+
+set -e
+
+CMD=$(python3 -c "
+import json, sys
+try:
+    print(json.load(sys.stdin).get('tool_input', {}).get('command', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+# Strip leading whitespace and any pre-command env var assignments (e.g.
+# `FOO=bar git push ...`). Cheap heuristic — drop tokens containing '='
+# until we find one that doesn't.
+CMD=$(echo "$CMD" | sed -E 's/^[[:space:]]+//')
+while echo "$CMD" | head -c 64 | grep -qE '^[A-Z_]+=[^[:space:]]+[[:space:]]+'; do
+  CMD=$(echo "$CMD" | sed -E 's/^[A-Z_]+=[^[:space:]]+[[:space:]]+//')
+done
+
+case "$CMD" in
+  "git push"*|"git -"*"push "*|*"&& git push"*)
+    cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"REMINDER: Use the git-push skill for this git push. Invoke it via the Skill tool (skill name: git-push) — it handles pre-push safety checks, PR creation if missing, CI watch, and the fix-commit-push loop."}}
+EOF
+    ;;
+  "gh pr create"*)
+    cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"REMINDER: PR creation is part of the git-push skill now. Invoke /git-push — it handles labels, linked-issue verification, the Closes-keyword formatting rule, and pushes to remote in one flow."}}
+EOF
+    ;;
+  "gh pr merge"*)
+    cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"REMINDER: Use the git-merge skill for this merge. Invoke /git-merge — it runs the validation pipeline (security-review, test-completeness, linked-issue verification), waits for explicit user confirmation, then merges with --auto (worktree-aware) and verifies issue closures."}}
+EOF
+    ;;
+esac
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -q 'git push'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"REMINDER: Use the git-push skill for this git push. Invoke it via the Skill tool (skill name: git-push) — it handles CI monitoring, branch safety, and the full merge workflow.\"}}'; elif echo \"$cmd\" | grep -q 'gh pr create'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"REMINDER: Use the git-pr-create skill for PR creation. Invoke it via the Skill tool (skill name: git-pr-create) — it drafts titles, selects labels, and opens the PR following monorepo conventions.\"}}'; fi 2>/dev/null || true",
+            "command": "bash ~/.claude/hooks/skill-reminder.sh",
             "statusMessage": "Checking skill requirements..."
           }
         ]


### PR DESCRIPTION
## Summary

Companion to [backmanfyi/backmanfyi#281](https://github.com/backmanfyi/backmanfyi/pull/281) (skill consolidation).

### Three improvements to the user-level PreToolUse Bash reminder hook

**1. Move the inline hook into a standalone script** (`claude/hooks/skill-reminder.sh`). The old inline `cmd | grep -q '...'` ran against the full command including args/heredoc bodies, so commit messages mentioning the literal strings false-positived. Today's session fired the nudge ~6 times on commit messages alone. New rule: case-match on the leading tokens after stripping env-var prefixes (e.g. `FOO=bar git push ...`).

**2. Add a `gh pr merge` nudge** pointing to the new git-merge skill (introduced in the companion PR). Previously `gh pr merge` was uncovered — the project CLAUDE.md flagged this gap explicitly.

**3. Update the `gh pr create` nudge** to point at `/git-push` instead of the deleted `git-pr-create` skill.

## Test plan

- [x] `python3 -m json.tool` on settings.json → valid
- [x] `bash -n` on the new script → syntax OK
- [x] Smoke test:
  - `git commit -m "...gh pr create flow..."` → no nudge (was false-positive before)
  - `git push -u origin foo` → nudges to git-push ✓
  - `gh pr create --title x` → nudges to git-push ✓
  - `gh pr merge 274` → nudges to git-merge ✓
- [ ] After merge: open new Claude session in backmanfyi monorepo; run `git commit -m "...gh pr merge..."` and verify no nudge fires.

## Breaking changes

None. The hook is still warn-only (exit 0). Behaviour is strictly improved (fewer false positives + new coverage).