### PR TITLE
chore(claude): inline skill-reminder hook, auto mode default

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -38,7 +38,8 @@
       "Bash(tofu output:*)",
       "Bash(tofu version:*)",
       "Bash(tofu providers:*)"
-    ]
+    ],
+    "defaultMode": "auto"
   },
   "hooks": {
     "PreToolUse": [
@@ -47,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ~/.claude/hooks/skill-reminder.sh",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -q 'git push'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"REMINDER: Use the git-push skill for this git push. Invoke it via the Skill tool (skill name: git-push) — it handles CI monitoring, branch safety, and the full merge workflow.\"}}'; elif echo \"$cmd\" | grep -q 'gh pr create'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"REMINDER: Use the git-pr-create skill for PR creation. Invoke it via the Skill tool (skill name: git-pr-create) — it drafts titles, selects labels, and opens the PR following monorepo conventions.\"}}'; fi 2>/dev/null || true",
             "statusMessage": "Checking skill requirements..."
           }
         ]
@@ -63,6 +64,8 @@
       }
     ]
   },
+  "theme": "light",
+  "skipAutoPermissionPrompt": true,
   "mcpServers": {
     "github": {
       "command": "docker",
@@ -110,5 +113,5 @@
       }
     }
   },
-  "theme": "light"
+  "skipDangerousModePermissionPrompt": true
 }


### PR DESCRIPTION
## Summary
- `permissions.defaultMode: "auto"` — auto-accept by default
- Inline the skill-reminder hook into settings.json (was sourcing `~/.claude/hooks/skill-reminder.sh`); extend to also nudge `gh pr create` toward the `git-pr-create` skill
- `skipAutoPermissionPrompt` + `skipDangerousModePermissionPrompt` — don't prompt when switching into auto/dangerous mode
- Move duplicate `theme: "light"` key (was listed twice)

## Notes
- Inlined hook duplicates `~/.claude/hooks/skill-reminder.sh` — pick one source of truth in a follow-up to avoid drift
- Hook grep matches `git push` / `gh pr create` anywhere in the command, including inside commit message strings — produces false positives (observed during this branch's commit)

## Test plan
- [ ] `defaultMode: "auto"` blocks direct pushes to main (verified in branch — classifier denied a `git push origin main` chained command)
- [ ] Skill reminder fires for `git push` and `gh pr create` commands