### PR TITLE
fix(tmux): emit update-indicator glyph as raw UTF-8 bytes

### DIFF
--- a/dot_config/tmux/scripts/check-updates.sh
+++ b/dot_config/tmux/scripts/check-updates.sh
@@ -24,5 +24,8 @@ behind=$(chezmoi git -- rev-list --count main..origin/main 2>/dev/null || echo 0
 if [ "$behind" -eq 0 ]; then
   : > "$STATE_FILE"
 else
-  printf '  ' > "$STATE_FILE"
+  # Cloud-download glyph (nf-md-cloud-download, U+F0162) + ' update ' label.
+  # Written as raw UTF-8 hex bytes (F3 B0 85 A2) — the literal character
+  # was being silently stripped at tool boundaries.
+  printf ' \xf3\xb0\x85\xa2 update ' > "$STATE_FILE"
 fi


### PR DESCRIPTION
Follow-up to #23.

The cloud-download character in `check-updates.sh` was getting stripped silently before reaching disk — the state file ended up containing just two spaces, making the indicator effectively invisible. Confirmed by `xxd ~/.local/state/chezmoi/update-status` showing `20 20` instead of the expected 4-byte UTF-8 sequence.

Rewritten to emit the bytes explicitly:

```sh
printf ' \xf3\xb0\x85\xa2 update ' > "$STATE_FILE"
```

- `F3 B0 85 A2` is the UTF-8 encoding of U+F0162 (`nf-md-cloud-download`)
- Added the literal text `update` after the glyph for visual weight at status-bar font sizes (the single-cell icon alone was very small)

## Verification

Live-tested by manually writing the bytes to the state file and running `tmux refresh-client -S` — indicator visible in rose (#b4637a) at the left edge of `status-right`.

## Test plan

- [ ] CI passes
- [ ] After merge: `chezmoi update` pulls this; next launchd run (within 15 min) re-writes the state file using the correct bytes