### PR TITLE
chore(claude): enable gopls-lsp plugin

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -q 'git push'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"REMINDER: Use the git-push skill for this git push. Invoke it via the Skill tool (skill name: git-push) — it handles CI monitoring, branch safety, and the full merge workflow.\"}}'; elif echo \"$cmd\" | grep -q 'gh pr create'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"REMINDER: Use the git-pr-create skill for PR creation. Invoke it via the Skill tool (skill name: git-pr-create) — it drafts titles, selects labels, and opens the PR following monorepo conventions.\"}}'; fi 2>/dev/null || true",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -q 'git push'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"REMINDER: Use the git-push skill for this git push. Invoke it via the Skill tool (skill name: git-push) — it handles CI monitoring, branch safety, and the full merge workflow.\"}}'; elif echo \"$cmd\" | grep -q 'gh pr create'; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"REMINDER: Use the git-push skill for the full push → PR → babysit CI workflow. Invoke it via the Skill tool (skill name: git-push) — Phase 6 opens the PR following monorepo conventions.\"}}'; fi 2>/dev/null || true",
             "statusMessage": "Checking skill requirements..."
           }
         ]
@@ -64,6 +64,10 @@
       }
     ]
   },
+  "enabledPlugins": {
+    "gopls-lsp@claude-plugins-official": true
+  },
+  "skipDangerousModePermissionPrompt": true,
   "theme": "light",
   "skipAutoPermissionPrompt": true,
   "mcpServers": {
@@ -112,6 +116,5 @@
         "ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS": "true"
       }
     }
-  },
-  "skipDangerousModePermissionPrompt": true
+  }
 }


### PR DESCRIPTION
Small follow-up of #23.

## Changes

- Enables `gopls-lsp@claude-plugins-official` via `enabledPlugins`. Was tracked in a stale unstaged edit on the migration branch — committing it now that the migration is in.
- Moves `skipDangerousModePermissionPrompt` next to the other top-level booleans (`theme`, `skipAutoPermissionPrompt`). No behaviour change, just file hygiene.
- Updates the PreToolUse hook's `gh pr create` branch to reference the `git-push` skill (which handles the full push → PR workflow) instead of the older `git-pr-create` name. Matches what the hook reminders I get actually say.

## Test plan

- [ ] CI passes
- [ ] After merge: `chezmoi update` pulls; `~/.claude/settings.json` symlink picks up the new content automatically (no re-apply needed)