### PR TITLE
feat(tmux): include keybinding hint in update indicator

### DIFF
--- a/dot_config/tmux/scripts/check-updates.sh
+++ b/dot_config/tmux/scripts/check-updates.sh
@@ -24,8 +24,9 @@ behind=$(chezmoi git -- rev-list --count main..origin/main 2>/dev/null || echo 0
 if [ "$behind" -eq 0 ]; then
   : > "$STATE_FILE"
 else
-  # Cloud-download glyph (nf-md-cloud-download, U+F0162) + ' update ' label.
-  # Written as raw UTF-8 hex bytes (F3 B0 85 A2) — the literal character
-  # was being silently stripped at tool boundaries.
-  printf ' \xf3\xb0\x85\xa2 update ' > "$STATE_FILE"
+  # Cloud-download glyph (nf-md-cloud-download, U+F0162) + descriptive
+  # label including the tmux keybinding hint. Written as raw UTF-8 hex
+  # bytes (F3 B0 85 A2) — the literal character was being silently
+  # stripped at tool boundaries.
+  printf ' \xf3\xb0\x85\xa2 update dotfiles [C-q U] ' > "$STATE_FILE"
 fi


### PR DESCRIPTION
Tiny polish on top of #24.

The indicator now reads ` update dotfiles [C-q U]` instead of just ` update`. The bracketed `[C-q U]` surfaces the existing `prefix + U` binding that opens a popup running `chezmoi update -v` — discoverable for future-me who's forgotten the binding.

Live-tested in tmux; renders correctly with the same dawnfox rose colour as before.

## Test plan

- [ ] CI passes
- [ ] After merge: next time `origin/main` is ahead, the launchd job writes the new label and the status bar shows the binding hint