### PR TITLE
chore(git): use GitHub noreply email

### DIFF
--- a/dot_config/git/config
+++ b/dot_config/git/config
@@ -1,6 +1,6 @@
 [user]
 	name = Lars Backman
-	email = lars@backman.fyi
+	email = 2622072+backmanfyi@users.noreply.github.com
 	signingkey = key::ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILTvy5M5TUKRu82gZXhS195/GjB6phYJO0bzutx5sxCG
 
 [include]


### PR DESCRIPTION
## Summary
- Switch global git identity to the GitHub noreply email (`2622072+backmanfyi@users.noreply.github.com`).
- Stops squash-merged PRs from rendering as "backmanfyi and Lars Backman authored" — the PR author (noreply) and the original commit author (real email) used to collide into a dual-author display.

## Test plan
- [x] `git config --get user.email` returns the noreply address
- [ ] Next squash-merged PR shows a single author in the GitHub UI