### PR TITLE
fix(zsh): let Tab run completion regardless of autosuggestions

### DIFF
--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -71,16 +71,9 @@ FPATH="/opt/homebrew/share/zsh/site-functions:${FPATH}"
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=#c4b8c0"
 source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 
-# Tab accepts one word of autosuggestion at a time, otherwise normal completion
-_autosuggest_or_complete() {
-  if [[ -n $POSTDISPLAY ]]; then
-    zle forward-word
-  else
-    zle expand-or-complete
-  fi
-}
-zle -N _autosuggest_or_complete
-bindkey '\t' _autosuggest_or_complete
+# Ctrl+F accepts one word of autosuggestion; Tab keeps zsh's default completion.
+# Right arrow accepts the whole suggestion (zsh-autosuggestions default).
+bindkey '^F' forward-word
 
 # pyenv (lazy-loaded)
 export PYENV_ROOT="$HOME/.pyenv"


### PR DESCRIPTION
## Summary
- Drop the custom \`_autosuggest_or_complete\` widget bound to Tab. It branched on \`\$POSTDISPLAY\` (set whenever zsh-autosuggestions had a ghosted suggestion visible, i.e. nearly always), so Tab routed to \`forward-word\` and accepted the suggestion instead of running file completion. Symptom: \`~/Doc<TAB>\` walked into a history-suggested path rather than completing to \`~/Documents\`.
- Bind Ctrl+F to \`forward-word\` for accept-one-word-of-suggestion. Right arrow continues to accept the whole suggestion (zsh-autosuggestions default).

## Test plan
- [ ] Open a new shell; \`~/Doc<TAB>\` completes to \`~/Documents\`
- [ ] \`~/Documents/<TAB>\` lists directory contents
- [ ] Ctrl+F accepts one word of an autosuggestion
- [ ] Right arrow still accepts the whole suggestion