### PR TITLE
feat(tmux): vi copy mode with yank to macOS clipboard

### DIFF
--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -100,6 +100,18 @@ bind-key -n User1 run-shell -b "${XDG_CONFIG_HOME}/tmux/scripts/zoom.sh out"
 bind-key -n User2 run-shell -b "${XDG_CONFIG_HOME}/tmux/scripts/zoom.sh reset"
 
 # -------------------------------
+# Copy Mode
+# -------------------------------
+# vi keys in copy mode; yank into the macOS clipboard via pbcopy.
+# set-clipboard on mirrors selections via OSC 52, so copies from remote
+# tmux sessions over SSH also reach the local clipboard (Ghostty supports it).
+set -g mode-keys vi
+set -g set-clipboard on
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "pbcopy"
+
+# -------------------------------
 # Styling
 # -------------------------------
 


### PR DESCRIPTION
## Summary
- \`mode-keys vi\` for copy mode (matches the \`bindkey -v\` setup in zsh).
- \`v\` starts a selection; \`y\` and \`Enter\` pipe the selection through \`pbcopy\` and exit copy mode — mirrors vim's yank-and-leave-visual behaviour.
- \`set-clipboard on\` mirrors selections via OSC 52, so copies from a remote tmux over SSH also reach the local clipboard (Ghostty supports OSC 52).

## Test plan
- [ ] Reload (\`prefix R\`), enter copy mode (\`prefix [\`), move with \`hjkl\`, \`v\` to select, \`y\` to yank
- [ ] Paste with \`cmd+v\` outside tmux — selection is present
- [ ] (Optional) SSH into a remote host with tmux installed, repeat — selection reaches the local clipboard via OSC 52