### PR TITLE
docs(claude): require inline source links in citations

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -61,6 +61,7 @@
 
 - Keep explanations concise - bullet points over paragraphs
 - Skip obvious context I already know
+- When citing a source (blog post, doc, repo, article), embed the URL as an inline markdown hyperlink at the point of mention — e.g. `[Block's manifesto](https://block.xyz/...)`. A trailing Sources section is fine as an index, but it must not be the only place URLs appear.
 
 ## Skill reminder hook
 


### PR DESCRIPTION
## Summary
- Add a Communication rule: when citing a source, embed the URL as an inline markdown hyperlink at the point of mention, not just in a trailing Sources section.

## Why
Surfacing URLs inline lets me click through from where a claim is made, instead of scrolling to a footer and matching titles to references.