### PR TITLE
refactor(claude): redesign user CLAUDE.md, add authoring skill and protected-branch hook

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -1,78 +1,48 @@
 # Personal Claude Code Preferences
 
-## About Me
+## Hard rules
 
-- Platform Engineer / Infrastructure Engineer + Full-stack TypeScript developer
-- Focus: IaC, Kubernetes, cloud infrastructure, DevOps, Astro/React, Cloudflare Workers
+- NEVER push to `main`/`master`. Work on a `<type>/<short-description>` branch (e.g. `fix/auth-bug`, `feat/new-api`).
+- Ask before any `git push`.
+- Secrets: fetch at runtime from 1Password via `op`; never write secret values to disk (no plaintext in `.env`, shell rc, or chezmoi templates).
+- Containers: use `podman`, never `docker`.
+- Required CLI tools must be declared in the Brewfile — don't paper over absence with `command -v` checks.
+- Commit messages: short, no AI boilerplate (no emoji, no "Generated with Claude Code" footer, no Co-Authored-By).
 
-## Permissions - Auto-Allow
+## Permissions — auto-allow (no need to ask)
 
-- Always read files without asking for permission
-- Always run `kubectl get` commands without asking
-- Always run read-only exploration commands (ls, cat, grep, find, etc.)
-- Always run read-only `gh` commands without asking (issue list/view, pr list/view/status/checks/diff, run list/view, workflow list/view, release list/view, repo view, auth status)
+- Read any file.
+- Read-only exploration: `ls`, `cat`, `grep`, `find`, etc.
+- `kubectl get`.
+- Read-only `gh`: issue list/view, pr list/view/status/checks/diff, run list/view, workflow list/view, release list/view, repo view, auth status.
 
-## Git Safety
+## Response style
 
-- NEVER push to main or master branches
-- Always create feature branches for changes
-- Always ask before any git push operation
-- Commit messages: short and concise, no AI-generated boilerplate (skip the emoji, "Generated with Claude Code" footer, and Co-Authored-By lines)
-- Branch naming: `<type>/<short-description>` (e.g., `fix/auth-bug`, `feat/new-api`)
+Default to the shortest answer that fully resolves the question; expand only when I ask.
 
-## Workflow
+- Lead with the answer. No preamble ("Sure", "Great question"), no closing summary restating what you did, no recapping my request back to me.
+- Simple/factual → one line or 1–3 sentences. Complex/open-ended → as long as needed, in bullets.
+- Cap routine answers at ~6 bullets / ~150 words unless I ask for more.
+- Never agree reflexively ("You're absolutely right"). If I'm wrong, say so.
+- Override: "deep dive" / "explain fully" / "verbose" lifts these caps.
 
-1. Read the codebase for relevant files and plan the work
-2. For multi-step tasks, create a GitHub issue to track it: `gh issue create --title "..." --label "..."`
-3. Check in with me to verify the plan before starting work
-4. Work through the steps, giving high-level explanations at each milestone
-5. Close the issue when the PR merges: `gh issue close <number>`
-6. Use `gh issue list` to review outstanding work at the start of a session
+## Sourcing & citations
 
-(Issue label sets are repo-specific — see each project's CLAUDE.md.)
+IMPORTANT: when I ask you to research something, or you pull information from the web or external docs/blogs/repos, cite it IEEE-style:
 
-## Implementation Approach
+- Inline bracketed numeral at the point of mention — "…as Block describes [1]". Reuse the same number for repeated cites of one source.
+- End the response with a numbered References list; each entry carries the full URL: `[1] Org, "Title," https://…`.
+- No real URL for a claim? Say so and label it unverified from training knowledge — never invent a citation.
+- Everyday answers derived from the codebase don't need citations.
 
-- ALWAYS present multiple options/approaches before starting any implementation
-- Explain trade-offs for each option
-- Wait for my selection before proceeding with code changes
-- When there are architectural decisions, list at least 2-3 alternatives
-- Keep changes as simple as possible - minimal code impact
-- Find root causes, no temporary fixes
-- Only touch code relevant to the task - avoid introducing bugs
+## Working style
 
-## Environment & tooling
+- Before implementing anything non-trivial, present 2–3 approaches with trade-offs and wait for my pick.
+- For tracked, multi-step work: open a GitHub issue (`gh issue create`), confirm the plan with me, then close it when the PR merges (`gh issue close <n>`). Skip the ceremony for throwaway tasks. (Label sets are repo-specific — see the project's CLAUDE.md.)
+- Touch only files relevant to the task; no unrequested refactors. Fix root causes, not symptoms.
+- Summarize at each milestone that changes files.
+- Delegate specialist work to the matching subagent — they own the detailed conventions: TypeScript/Astro/React/Workers → `typescript-expert`; Terraform/infra → `terraform-expert`; tests (Vitest/Playwright) → `testing-expert`; plus the other `*-expert` agents as relevant. Let linters/`tsc` enforce mechanical style.
 
-- **Secrets**: fetch at runtime from 1Password via the `op` CLI. Convention: vault `env`, item type Password, item name = env-var name, reference `op://env/<VAR>/password`. Per-tool env files at `~/.config/op/env/<tool>.env` are auto-wrapped by zshrc into `op run --env-file=… -- <tool>` functions; bypass with `command <tool>`. Never write secret values into any tracked file — no plaintext API keys, tokens, or credentials in `.env`, shell rc, chezmoi templates, or anywhere else on disk.
-- **System packages**: required CLI tools must be declared in `~/.config/dotfiles/Brewfile`. If a script depends on it, add `brew "<pkg>"` — don't paper over absence with `command -v` checks.
-- **Containers**: use `podman` for local container workflows. Do not introduce `docker` commands; when porting recipes, swap the binary and verify the flags.
+## About me
 
-## Code Style
-
-- Clear, readable variable and function names instead of comments (clean and straightforward code)
-- Only add comments for non-obvious business logic or "why" explanations
-- NO lazy type workarounds - add proper enum values instead of `| string`, extend interfaces properly instead of using `any` or type assertions
-
-## TypeScript
-
-- Strict mode always — no `any`; use `unknown` with type narrowing instead
-- `const` over `let`, never `var`
-- `async/await` over `.then()` chains
-- Named exports preferred; default exports only for Astro pages/layouts
-- Zod for runtime validation at system boundaries (API inputs, env vars)
-- pnpm for package management — never npm or yarn in JS/TS projects
-- vitest for unit tests; Playwright for E2E. The exact `pnpm` invocation depends on whether the project uses Turborepo or a single package — check the project's CLAUDE.md.
-
-## Communication
-
-- Keep explanations concise - bullet points over paragraphs
-- Skip obvious context I already know
-- When citing a source (blog post, doc, repo, article), embed the URL as an inline markdown hyperlink at the point of mention — e.g. `[Block's manifesto](https://block.xyz/...)`. A trailing Sources section is fine as an index, but it must not be the only place URLs appear.
-
-## Skill reminder hook
-
-The user-level `PreToolUse` hook on `Bash` prints a reminder when it sees `git push` or `gh pr create` in a command, nudging toward the project's `git-push` / `git-pr-create` skills. **It does not block — the underlying command still runs.** Treat it as a prompt, not a guardrail.
-
-## Outbound MCP write hook
-
-The user-level `PreToolUse` hook on Fastmail/Slack send/canvas/delete tools logs every outbound write to `~/.claude/audit.log` and prints a lethal-trifecta reminder. Reaches every Claude Code session, not just one project. Warn-only today; can be graduated to `exit 2` (block) if an incident occurs.
+Platform / infrastructure engineer + full-stack TypeScript developer — IaC, Kubernetes, cloud, DevOps, Astro/React, Cloudflare Workers.

--- a/dot_claude/hooks/block-push-to-protected.sh
+++ b/dot_claude/hooks/block-push-to-protected.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# PreToolUse hook (Bash matcher): HARD-BLOCK any `git push` that targets a
+# protected branch (main/master). Deterministic backstop for the CLAUDE.md
+# "never push to main" rule — advisory prose can be ignored; this cannot.
+#
+# Only real push *invocations* count: the command is split into segments on
+# shell separators (&& || ; |) and a segment is evaluated only if its command
+# is `git … push`. This avoids false positives when "git push" / "main" merely
+# appear inside a quoted argument such as a commit message or PR body.
+#
+# Denies when:
+#   - an explicit refspec targets main/master
+#     (git push origin main, git push origin HEAD:main, git push -f origin master), OR
+#   - the push has no explicit refspec (bare `git push`, `git push origin`)
+#     and the CURRENT branch is main/master.
+# Allows every feature-branch push.
+
+CMD=$(jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+[ -z "$CMD" ] && exit 0
+
+deny() {
+  jq -nc --arg r "$1" \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+  exit 0
+}
+
+# Split the command into segments, one per shell separator, so only a segment
+# whose command is `git … push` gets evaluated.
+SEGMENTS=$(printf '%s' "$CMD" | sed -E 's/\|\||&&|;|\|/\
+/g')
+
+oldIFS=$IFS
+IFS='
+'
+set -f
+for seg in $SEGMENTS; do
+  seg=$(printf '%s' "$seg" | sed -E 's/^[[:space:]]+//;s/[[:space:]]+$//')
+
+  # Strip leading VAR=value env assignments (e.g. `GIT_SSH=… git push …`).
+  while printf '%s' "$seg" | grep -qE '^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+'; do
+    seg=$(printf '%s' "$seg" | sed -E 's/^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+[[:space:]]*//')
+  done
+
+  # The segment's command must be `git`.
+  case "$seg" in
+    git | git\ *) ;;
+    *) continue ;;
+  esac
+  rest=$(printf '%s' "$seg" | sed -E 's/^git[[:space:]]+//')
+
+  # Strip git global options; value-taking ones consume the following token.
+  while :; do
+    case "$rest" in
+      -C\ * | -c\ * | --git-dir\ * | --work-tree\ * | --namespace\ * | --exec-path\ *)
+        rest=$(printf '%s' "$rest" | sed -E 's/^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+//') ;;
+      -*)
+        rest=$(printf '%s' "$rest" | sed -E 's/^[^[:space:]]+[[:space:]]+//') ;;
+      *) break ;;
+    esac
+  done
+
+  # The git subcommand must be `push`.
+  case "$rest" in
+    push | push\ *) ;;
+    *) continue ;;
+  esac
+  pushargs=$(printf '%s' "$rest" | sed -E 's/^push//')
+
+  # 1. Explicit main/master target anywhere in the refspec args.
+  if printf '%s' "$pushargs" | grep -qE '(^|[[:space:]:/])(main|master)([[:space:]:]|$)'; then
+    deny "Blocked: push targets a protected branch (main/master). Per CLAUDE.md, never push to main — open a feature branch and a PR instead."
+  fi
+
+  # 2. No explicit refspec (<=1 positional) while HEAD is protected => bare push
+  #    would publish main/master.
+  poscount=$(printf '%s' "$pushargs" | tr ' ' '\n' | grep -vE '^-' | grep -cvE '^$')
+  if [ "$poscount" -le 1 ]; then
+    branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    case "$branch" in
+      main | master)
+        deny "Blocked: bare 'git push' while on '$branch' would publish a protected branch. Per CLAUDE.md, never push to main — switch to a feature branch."
+        ;;
+    esac
+  fi
+done
+IFS=$oldIFS
+set +f
+exit 0

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -101,6 +101,16 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh ~/.claude/hooks/block-push-to-protected.sh",
+            "statusMessage": "Checking branch protection..."
+          }
+        ]
+      },
+      {
         "matcher": "mcp__fastmail__send_email|mcp__fastmail__send_draft|mcp__fastmail__reply_email|mcp__fastmail__delete_email|mcp__fastmail__bulk_delete|mcp__claude_ai_Slack__slack_send_message|mcp__claude_ai_Slack__slack_send_message_draft|mcp__claude_ai_Slack__slack_schedule_message|mcp__claude_ai_Slack__slack_create_canvas|mcp__claude_ai_Slack__slack_update_canvas",
         "hooks": [
           {
@@ -114,8 +124,9 @@
   "enabledPlugins": {
     "gopls-lsp@claude-plugins-official": true
   },
-  "preferredNotifChannel": "terminal_bell",
   "skipDangerousModePermissionPrompt": true,
+  "theme": "light-daltonized",
+  "preferredNotifChannel": "terminal_bell",
   "skipAutoPermissionPrompt": true,
-  "theme": "light-daltonized"
+  "skipWorkflowUsageWarning": true
 }

--- a/dot_claude/skills/claude-md-authoring/SKILL.md
+++ b/dot_claude/skills/claude-md-authoring/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: claude-md-authoring
+description: >
+  Principles and workflow for writing or editing any Claude instruction file —
+  user-level CLAUDE.md (~/.claude/CLAUDE.md), project CLAUDE.md (./CLAUDE.md or
+  ./.claude/CLAUDE.md), CLAUDE.local.md, subagent definitions
+  (.claude/agents/*.md), and path-scoped rules (.claude/rules/*.md). Use
+  whenever creating, restructuring, trimming, or adding a rule to any of these
+  files, and especially when deciding WHERE a new instruction or preference
+  belongs (CLAUDE.md vs. skill vs. subagent vs. hook vs. linter). Triggers:
+  "add this to CLAUDE.md", "update my Claude instructions", "this file is too
+  long / swamps context", "where should this rule go", "review my CLAUDE.md",
+  "make a rule for…", editing any *-expert.md agent file.
+---
+
+# Authoring Claude instruction files
+
+Every CLAUDE.md is loaded **in full into every session**. Instruction-following
+degrades as the rule count rises (frontier models follow ~150–200 reliably, and
+the harness already spends ~50), so a bloated file makes Claude *ignore* the
+rules that matter. Therefore: **every line must earn its tokens, and most
+content does not belong in CLAUDE.md at all.** This skill is the gate for any
+edit to these files.
+
+## First: route the content (the core decision)
+
+Before adding ANY instruction, run it through this test in order. Most content
+gets redirected away from CLAUDE.md.
+
+1. **Must it hold every session, even when the agent is working on something
+   unrelated?** (e.g. "never push to main", response style, secrets policy)
+   → Belongs in **CLAUDE.md**. Keep it to one tight line. Pick the scope: user
+   if it's true for *all* your projects, project if it's true for *this repo*.
+
+2. **Must it happen every time with zero exceptions, or is it mechanically
+   checkable?** (e.g. block-push-to-main, formatting, `const` over `let`)
+   → Use a **hook** (deterministic) or a **linter/`tsc`** — NOT prose. CLAUDE.md
+   is advisory; never send an LLM to do a linter's job.
+
+3. **Is it detailed, procedural, or only sometimes relevant?** (e.g. a release
+   runbook, framework conventions, a domain workflow)
+   → Use a **skill** (a multi-step workflow), a **subagent** (`*-expert.md`
+   domain depth, loaded only when delegated), or a **path-scoped rule**
+   (`.claude/rules/*.md` with `paths:` frontmatter, loaded only when touching
+   matching files).
+
+4. **Is it discoverable from the codebase in seconds, or generic good practice
+   the model already follows?** (e.g. "write clean code", a file-by-file map)
+   → **Don't add it.** It's bloat.
+
+Only content that survives step 1 gets written into a CLAUDE.md. See
+`references/patterns.md` for the full placement table and the reasoning.
+
+## Authoring rules (for content that does belong in CLAUDE.md)
+
+- **Lean.** Target well under 200 lines (Anthropic's stated ceiling); shorter is
+  better. For every line ask: *"would removing this cause Claude to make a
+  mistake?"* If not, cut it.
+- **Specific and verifiable.** Measurable caps and exact formats beat adjectives.
+  Write "cap routine answers at ~6 bullets / ~150 words", never "be concise";
+  "run `pnpm turbo lint` before PR", never "test your changes".
+- **Most-important-first.** Lead with hard guardrails / prohibitions, where
+  attention is highest. Push identity/"about me" context to the bottom.
+- **One source of truth.** Never duplicate a rule across user and project files,
+  or between CLAUDE.md and a subagent file. State it once, at the narrowest
+  scope that covers it, and let the other layer reference it.
+- **Emphasis is rationed.** Reserve `IMPORTANT` / `NEVER` / `YOU MUST` for the
+  few genuine hard rules; if everything shouts, nothing does.
+- **Hand-write it.** Don't ship raw `/init` output — review every line.
+
+## Scope: user vs. project
+
+- **User (`~/.claude/CLAUDE.md`)** — true across *all* your projects: global
+  guardrails, response style, citation style, cross-project workflow, and
+  routing to your subagents. Not repo-specific anything.
+- **Project (`./CLAUDE.md`)** — true for *this repo*: build/test/lint commands,
+  architecture, repo conventions, issue-label sets. Team-shared, checked in.
+- A rule that names a repo-specific path, tool, or convention belongs in
+  **project** scope even if it feels personal. If you find the same rule in
+  both, delete it from the user file and keep the detailed version in project.
+
+## Workflow for an edit
+
+1. Identify the file and its scope (user / project / local / agent / rule).
+2. For each addition or change, run the **routing test** above. Redirect
+   anything that fails step 1 to a hook, linter, skill, subagent, rule, or the
+   trash — don't just paste it in.
+3. Write or trim following the **authoring rules**. Prefer editing down over
+   adding; when a section grows, that's a signal to split it out, not to keep it.
+4. Before finishing, verify against the checklist in `references/patterns.md`.
+5. Report the line-count delta and state explicitly what was cut, moved, or
+   redirected and where.
+
+## Reusable material
+
+Read `references/patterns.md` when you need: the full placement table, the
+non-obvious Claude Code mechanics (load order, `@import` caveat, advisory vs.
+deterministic), ready-to-paste rule blocks (response style, IEEE citations,
+subagent routing), a before/after example, the standard "cut list", and the
+pre-finish checklist.

--- a/dot_claude/skills/claude-md-authoring/references/patterns.md
+++ b/dot_claude/skills/claude-md-authoring/references/patterns.md
@@ -1,0 +1,141 @@
+# Patterns & reference: authoring Claude instruction files
+
+Contents:
+- [Placement table](#placement-table)
+- [Claude Code mechanics you must know](#claude-code-mechanics-you-must-know)
+- [Reusable rule blocks](#reusable-rule-blocks)
+- [The cut list](#the-cut-list)
+- [Before / after example](#before--after-example)
+- [Pre-finish checklist](#pre-finish-checklist)
+
+## Placement table
+
+Route every candidate instruction to its correct home. CLAUDE.md is the
+*last* resort, not the default.
+
+| Content | Lives in | Why |
+|---|---|---|
+| Always-on guardrail / prohibition (never push to main, secrets policy) | **CLAUDE.md** (user or project) | Must be active every session, even off-topic. Short. |
+| Response style, citation style, cross-project workflow | **User CLAUDE.md** | True for all your projects. |
+| Build/test/lint commands, repo architecture, label sets | **Project CLAUDE.md** | True for this repo; team-shared. |
+| Personal, untracked notes for one repo | **CLAUDE.local.md** (gitignored) | Yours only; not for the team. |
+| Must-happen-every-time / mechanically checkable | **Hook** (PreToolUse/Stop) or **linter/`tsc`** | Deterministic; CLAUDE.md is only advisory. |
+| Framework/domain conventions, type design, code style | **Subagent** (`.claude/agents/*-expert.md`) | Loaded only when delegated; owns the depth. |
+| File-type-specific rules (e.g. only `src/api/**/*.ts`) | **Path-scoped rule** (`.claude/rules/*.md`, `paths:` frontmatter) | Loads only when touching matching files. |
+| Multi-step procedure / runbook | **Skill** (`.claude/skills/<n>/SKILL.md`) | Loads on demand by description match. |
+| Discoverable from code, or generic good practice | **Nowhere — delete** | Bloat; the model already does it. |
+
+## Claude Code mechanics you must know
+
+Non-obvious facts that drive correct placement:
+
+- **CLAUDE.md loads in full, every session.** Length is a per-turn input cost
+  paid on every conversation, not just once.
+- **`@path` imports do NOT save context.** Imported files are expanded into
+  context at launch (max depth 4 hops). Use imports for organization, never as
+  a context-reduction trick. The real levers for shrinking the always-on file
+  are skills, subagents, and path-scoped rules.
+- **CLAUDE.md is advisory, hooks are deterministic.** CLAUDE.md is delivered as
+  a user message — no guaranteed compliance, especially for vague or conflicting
+  rules. A rule that *must* hold with zero exceptions belongs in a hook.
+- **Subagents have their own context** and do NOT inherit your CLAUDE.md. This
+  is why a `*-expert.md` agent restates its conventions — and why duplicating
+  those conventions in CLAUDE.md is pure redundancy and a drift risk.
+- **Load order is broadest → most specific:** enterprise/managed → user
+  (`~/.claude/CLAUDE.md`) → project (`./CLAUDE.md`) → local
+  (`./CLAUDE.local.md`). Contradictions across layers make Claude pick one
+  arbitrarily — avoid them.
+- **Specificity + emphasis tune adherence.** `IMPORTANT`/`YOU MUST` raise the
+  odds a soft rule sticks, but they don't make it deterministic — and overuse
+  burns their signal.
+
+## Reusable rule blocks
+
+Proven, ready-to-paste. Adapt wording, keep the structure.
+
+### Response style (verbosity control)
+
+```markdown
+## Response style
+Default to the shortest answer that fully resolves the question; expand only when I ask.
+- Lead with the answer. No preamble ("Sure", "Great question"), no closing summary
+  restating what you did, no recapping my request back to me.
+- Simple/factual → one line or 1–3 sentences. Complex/open-ended → as long as needed, in bullets.
+- Cap routine answers at ~6 bullets / ~150 words unless I ask for more.
+- Never agree reflexively ("You're absolutely right"). If I'm wrong, say so.
+- Override: "deep dive" / "explain fully" / "verbose" lifts these caps.
+```
+
+### Sourcing & citations (IEEE)
+
+```markdown
+## Sourcing & citations
+IMPORTANT: when I ask you to research something, or you pull information from the web
+or external docs/blogs/repos, cite it IEEE-style:
+- Inline bracketed numeral at the point of mention — "…as Block describes [1]".
+  Reuse the same number for repeated cites of one source.
+- End the response with a numbered References list; each entry carries the full URL:
+  `[1] Org, "Title," https://…`. This list is the canonical home of the URL.
+- No real URL for a claim? Say so and label it unverified from training knowledge —
+  never invent a citation.
+- Everyday answers derived from the codebase don't need citations.
+```
+
+### Subagent routing (instead of inlining conventions)
+
+```markdown
+- Delegate specialist work to the matching subagent — they own the detailed
+  conventions: TypeScript/Astro/React/Workers → `typescript-expert`;
+  Terraform/infra → `terraform-expert`; tests → `testing-expert`; plus the
+  other `*-expert` agents as relevant. Let linters/`tsc` enforce mechanical style.
+```
+
+## The cut list
+
+Delete on sight when found in a CLAUDE.md:
+
+- Generic good practice: "write clean code", "use best practices", "avoid bugs",
+  "be careful", "think step by step".
+- Standard language/tooling conventions the model already follows.
+- Detailed API docs or long tutorials — link to the source instead.
+- File-by-file codebase descriptions — discoverable by reading the code.
+- Stale instructions describing how the code *used to* work.
+- Anything duplicated in another CLAUDE.md layer or a subagent file.
+- Meta-commentary documenting what a hook already does at runtime.
+- Pasted code snippets — reference `file:line` instead; snippets go stale.
+
+## Before / after example
+
+**Before** (vague, unenforceable, duplicated):
+
+```markdown
+## Communication
+- Keep explanations concise - bullet points over paragraphs
+- When citing a source, embed the URL as an inline markdown hyperlink.
+## TypeScript
+- Strict mode, no any; const over let; pnpm not npm.   ← duplicates typescript-expert
+```
+
+**After** (specific, routed, deduped):
+
+```markdown
+## Response style
+- Lead with the answer; cap routine replies at ~6 bullets / ~150 words unless asked.  (+ full block above)
+## Sourcing & citations
+- IMPORTANT: cite web/external facts IEEE-style …  (+ full block above)
+## Working style
+- Delegate TS work to `typescript-expert`; it owns the conventions.  ← no duplication
+```
+
+## Pre-finish checklist
+
+Before declaring an edit done:
+
+- [ ] Every new/changed line survives the routing test (step 1 = belongs here).
+- [ ] No rule is vague — each has a measurable cap or exact format.
+- [ ] No duplication across user/project layers or with a subagent file.
+- [ ] Hard guardrails are near the top; identity/context near the bottom.
+- [ ] Emphasis markers used only on genuine hard rules.
+- [ ] Anything mechanical/zero-exception was sent to a hook or linter, not prose.
+- [ ] Line-count delta reported; cuts and moves stated explicitly with destinations.
+- [ ] File is comfortably under 200 lines.


### PR DESCRIPTION
## Summary

Reworks the user-level Claude Code config around three principles drawn from current CLAUDE.md best practices: **lean context**, **always-on guardrails vs. on-demand depth**, and **deterministic enforcement over advisory prose**.

## Changes

**`dot_claude/CLAUDE.md` — redesign (79 → ~48 lines)**
- Reordered most-important-first: a `Hard rules` block now leads; `About me` is a one-liner at the bottom.
- New **Response style** section with concrete, checkable limits (lead with the answer, no preamble/sycophancy, ~6 bullets / ~150 words on routine replies, with a "deep dive" override) replacing the old unenforceable "keep explanations concise".
- New **Sourcing & citations** section: IEEE numbered references, scoped to researched/web-sourced answers, with a "never invent a citation" guard. Reverses the inline-hyperlink rule from 549fb8a (the two styles are mutually exclusive).
- Dropped the `Code & TypeScript` block — those conventions are already owned by the `typescript-expert` subagent; added a one-line routing pointer instead. Ends the duplication/drift.
- Trimmed duplicated secrets/podman/Brewfile guidance to one-liners (the project CLAUDE.md remains authoritative).

**`dot_claude/skills/claude-md-authoring/` — new skill**
- Encodes the routing test (always-on → CLAUDE.md / zero-exception → hook+linter / depth → skill·subagent·rule / discoverable → delete) and authoring rules for editing any instruction file (user or project CLAUDE.md, agents, rules).
- SKILL.md (100 lines) + `references/patterns.md` (placement table, mechanics, reusable rule blocks, cut list, checklist) via progressive disclosure.

**`dot_claude/hooks/block-push-to-protected.sh` + `settings.json` — new PreToolUse hook**
- Deterministic backstop for the "never push to main" rule: denies `git push` to `main`/`master`.
- Evaluates only genuine `git … push` command segments (split on shell separators, env-prefix and git-global-option aware), so "git push" / "main" inside a quoted commit message or PR body does **not** trigger it.

## Test evidence (hook)

| Command | Verdict |
|---|---|
| `git push origin main` | deny |
| `git push -f origin master` | deny |
| `git add -A && git push origin main` | deny |
| `git -C /repo push origin main` | deny |
| bare `git push` / `git push origin` while on `main` | deny |
| `git commit -m "blocks git push to main/master"` | allow |
| `git push origin feat/x`, `git push -u origin feat/x` | allow |
| bare `git push` on a feature branch | allow |

## Notes

- `Brewfile` and `.chezmoidata/claude.json` had pre-existing (unrelated) modifications and were intentionally left out of this branch.
- `settings.json` also carries some pre-existing harness tweaks (theme, `skipWorkflowUsageWarning`) that couldn't be cleanly separated from the hook addition.
